### PR TITLE
Simplify the `assert_compile_time_raise` macro

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,13 +2,11 @@ ExUnit.start()
 
 defmodule CompileTimeAssertions do
   defmacro assert_compile_time_raise(expected_exception, expected_message, fun) do
-    # At compile-time, the fun is in AST form and thus cannot raise.
-    # At run-time, we will evaluate this AST, and it may raise.
-    fun_quoted_at_runtime = {:quote, [], [[do: fun]]}
+    fun = Macro.escape(fun)
 
     quote do
       assert_raise unquote(expected_exception), unquote(expected_message), fn ->
-        Code.eval_quoted(unquote(fun_quoted_at_runtime))
+        Code.eval_quoted(unquote(fun))
       end
     end
   end


### PR DESCRIPTION
If you just escape the function you pass to your macro with `Macro.escape/1`, then unquoting it in the quoted part of the macro will insert the **AST** of the function (instead of the literal function, which raises at compile-time) in the quoted part. Let me know what you think :)
