### PR TITLE
Add capability to generate compile time warnings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,29 @@ end
 
 Starting December 1st 2015, the "fixme" line in the example above would raise a compile-time exception with the message "Fix by 2015-12-01: Stop hard-coding currency."
 
+You can additionally pass a parameter ```warn: true``` to issue a warning at compile time before the date:
+
+```elixir
+defmodule MyCode do
+  import FIXME
+
+  def my_function do
+    fixme 2020-12-01, "Stop hard-coding currency.", warn: true
+    currency = "USD"
+    # …
+  end
+end
+```
+
+will result in the following warning everytime the code is compiled before the date:
+
+```
+warning: Fix by 2020-12-01: Stop hard-coding currency.
+  lib/my_code.ex:5
+```
+
+Note, this will still raise on compile after the date passes.
+
 You may want to use these bad boys next to:
 
 * Temporary quick fixes, to ensure they really are temporary.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,11 @@ end
 
 Starting December 1st 2015, the "fixme" line in the example above would raise a compile-time exception with the message "Fix by 2015-12-01: Stop hard-coding currency."
 
-You can additionally pass a parameter ```warn: true``` to issue a warning at compile time before the date:
+An application wide setting can be enabled to emit warnings during compile time before the date provided to your fixme call.
+Adding:
 
 ```elixir
-defmodule MyCode do
-  import FIXME
-
-  def my_function do
-    fixme 2020-12-01, "Stop hard-coding currency.", warn: true
-    currency = "USD"
-    # …
-  end
-end
+config :fixme, warn: true
 ```
 
 will result in the following warning everytime the code is compiled before the date:
@@ -41,6 +34,20 @@ warning: Fix by 2020-12-01: Stop hard-coding currency.
 ```
 
 Note, this will still raise on compile after the date passes.
+
+You can additionally pass a parameter ```warn: true``` or ```warn: false``` to override the application settings:
+
+```elixir
+defmodule MyCode do
+  import FIXME
+
+  def my_function do
+    fixme 2020-12-01, "Stop hard-coding currency.", warn: false # does not raise the warning even if warn: true in application settings
+    currency = "USD"
+    # …
+  end
+end
+```
 
 You may want to use these bad boys next to:
 

--- a/lib/fixme.ex
+++ b/lib/fixme.ex
@@ -12,7 +12,7 @@ defmodule FIXME do
     # Opt into compile time warnings via the application get env
     # Pass the additional option 'warn' to override the application setting
     warn = case opts[:warn] do
-      nil  ->
+      nil ->
         Application.get_env(:fixme, :warn, false)
       warn ->
         warn
@@ -22,7 +22,7 @@ defmodule FIXME do
 
     message = "Fix by #{year}-#{zeropad month}-#{zeropad day}: #{message}"
     cond do
-      current_date >= fixme_date  ->
+      current_date >= fixme_date ->
         raise message
       warn ->
         %{file: file, line: line} = __CALLER__

--- a/lib/fixme.ex
+++ b/lib/fixme.ex
@@ -9,8 +9,14 @@ defmodule FIXME do
     # Injectable "today" for tests.
     current_date = opts[:today] || (:calendar.local_time |> elem(0))
 
-    # Opt into compile time warnings
-    warn = opts[:warn]
+    # Opt into compile time warnings via the application get env
+    # Pass the additional option 'warn' to override the application setting
+    warn = case opts[:warn] do
+      nil  ->
+        Application.get_env(:fixme, :warn, false)
+      warn ->
+        warn
+    end
 
     fixme_date = {year, month, day}
 

--- a/test/fixme_test.exs
+++ b/test/fixme_test.exs
@@ -8,7 +8,7 @@ defmodule FIXMETest do
     fixme 9999-07-01, "look for jetpack"
   end
 
-  test "warns during compile before the date if warn: true " do
+  test "warns during compile before the date if warn: true" do
     warning = capture_io(:stderr, fn ->
       Code.eval_string """
         import FIXME
@@ -18,7 +18,7 @@ defmodule FIXMETest do
     assert warning =~ "Fix by 9999-07-01: look for jetpack"
   end
 
-  test "does not warn during compile before the date if warn: false " do
+  test "does not warn during compile before the date if warn: false" do
     warning = capture_io(:stderr, fn ->
       Code.eval_string """
         import FIXME
@@ -28,7 +28,7 @@ defmodule FIXMETest do
     assert warning == ""
   end
 
-  test "does not warn during compile before the date if warn not provided " do
+  test "does not warn during compile before the date if warn not provided" do
     warning = capture_io(:stderr, fn ->
       Code.eval_string """
         import FIXME
@@ -49,6 +49,13 @@ defmodule FIXMETest do
     assert_compile_time_raise RuntimeError, "Fix by 9999-07-01: look for jetpack", fn ->
       import FIXME
       fixme 9999-07-01, "look for jetpack", today: {9999, 7, 1}
+    end
+  end
+
+  test "raises after date even if warn is true" do
+    assert_compile_time_raise RuntimeError, "Fix by 1983-07-26: be born", fn ->
+      import FIXME
+      fixme 1983-07-26, "be born", warn: true
     end
   end
 

--- a/test/fixme_test.exs
+++ b/test/fixme_test.exs
@@ -1,10 +1,41 @@
 defmodule FIXMETest do
   use ExUnit.Case
   import CompileTimeAssertions
+  import ExUnit.CaptureIO
 
   test "does not raise before date" do
     import FIXME
     fixme 9999-07-01, "look for jetpack"
+  end
+
+  test "warns during compile before the date if warn: true " do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack", warn: true
+      """
+    end)
+    assert warning =~ "Fix by 9999-07-01: look for jetpack"
+  end
+
+  test "does not warn during compile before the date if warn: false " do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack", warn: false
+      """
+    end)
+    assert warning == ""
+  end
+
+  test "does not warn during compile before the date if warn not provided " do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack"
+      """
+    end)
+    assert warning == ""
   end
 
   test "raises after date" do

--- a/test/fixme_test.exs
+++ b/test/fixme_test.exs
@@ -3,39 +3,17 @@ defmodule FIXMETest do
   import CompileTimeAssertions
   import ExUnit.CaptureIO
 
+  setup context do
+    if context[:warnings_enabled] do
+      Application.put_env(:fixme, :warn, true)
+      on_exit fn -> Application.delete_env(:fixme, :warn) end
+    end
+    :ok
+  end
+
   test "does not raise before date" do
     import FIXME
     fixme 9999-07-01, "look for jetpack"
-  end
-
-  test "warns during compile before the date if warn: true" do
-    warning = capture_io(:stderr, fn ->
-      Code.eval_string """
-        import FIXME
-        fixme 9999-07-01, "look for jetpack", warn: true
-      """
-    end)
-    assert warning =~ "Fix by 9999-07-01: look for jetpack"
-  end
-
-  test "does not warn during compile before the date if warn: false" do
-    warning = capture_io(:stderr, fn ->
-      Code.eval_string """
-        import FIXME
-        fixme 9999-07-01, "look for jetpack", warn: false
-      """
-    end)
-    assert warning == ""
-  end
-
-  test "does not warn during compile before the date if warn not provided" do
-    warning = capture_io(:stderr, fn ->
-      Code.eval_string """
-        import FIXME
-        fixme 9999-07-01, "look for jetpack"
-      """
-    end)
-    assert warning == ""
   end
 
   test "raises after date" do
@@ -52,10 +30,62 @@ defmodule FIXMETest do
     end
   end
 
+  test "warns during compile time before the date if passed warn: true during invokation, even if application setting not present" do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack", warn: true
+      """
+    end)
+    assert warning =~ "Fix by 9999-07-01: look for jetpack"
+  end
+
+  @tag warnings_enabled: true
+  test "warns during compile before the date if warn: true in application settings" do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack"
+      """
+    end)
+    assert warning =~ "Fix by 9999-07-01: look for jetpack"
+  end
+
+  @tag warnings_enabled: true
+  test "does not warn during compile before the date if warn: true in application setting, but passed warn: false in macro call" do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack", warn: false
+      """
+    end)
+    assert warning == ""
+  end
+
+  @tag warnings_enabled: true
+  test "warns during compile before the date if warn: true in application settings and in macro call" do
+    warning = capture_io(:stderr, fn ->
+      Code.eval_string """
+        import FIXME
+        fixme 9999-07-01, "look for jetpack", warn: true
+      """
+    end)
+    assert warning =~ "Fix by 9999-07-01: look for jetpack"
+  end
+
+  @tag warnings_enabled: true
+  test "raises on date even if warn is true" do
+    assert_compile_time_raise RuntimeError, "Fix by 9999-07-01: look for jetpack", fn ->
+      import FIXME
+      fixme 9999-07-01, "look for jetpack", today: {9999, 7, 1}
+    end
+  end
+
+  @tag warnings_enabled: true
   test "raises after date even if warn is true" do
     assert_compile_time_raise RuntimeError, "Fix by 1983-07-26: be born", fn ->
       import FIXME
-      fixme 1983-07-26, "be born", warn: true
+      fixme 1983-07-26, "be born"
     end
   end
 


### PR DESCRIPTION
Since recent versions of elixir are focussing on compile time warning thought this might come in handy.
